### PR TITLE
update bumblebee to depend on libglvnd (which replaces mesa-ligbl)

### DIFF
--- a/bumblebee-openrc/PKGBUILD
+++ b/bumblebee-openrc/PKGBUILD
@@ -7,11 +7,11 @@ _url=https://gitweb.gentoo.org/repo/gentoo.git/plain
 
 pkgname=bumblebee-openrc
 pkgver=3.2.1
-pkgrel=12
+pkgrel=13
 pkgdesc="NVIDIA Optimus support for Linux through Primus/VirtualGL"
 arch=('i686' 'x86_64')
 provides=('bumblebee')
-depends=('primus' 'glib2' 'mesa-libgl' 'openrc')
+depends=('primus' 'glib2' 'libglvnd' 'openrc')
 makedepends=('help2man' 'libbsd')
 optdepends=('xf86-video-nouveau: nouveau driver'
             'nouveau-dri: 3D acceleration features fo nouveau'


### PR DESCRIPTION
This change allowed me to install system updates that were being held back due to bumblebee-openrc's dependence on mesa-libgl. I did some basic testing and seems to function properly:

```
# cat /proc/acpi/bbswitch
0000:01:00.0 OFF

$ optirun glxgears

[while glxgears is running:]

# cat /proc/acpi/bbswitch
0000:01:00.0 ON

[after closing glxgears:]

# cat /proc/acpi/bbswitch
0000:01:00.0 OFF

```